### PR TITLE
地図と枠を同心円に変更

### DIFF
--- a/frontend/src/components/MadeRoute.tsx
+++ b/frontend/src/components/MadeRoute.tsx
@@ -158,8 +158,8 @@ export default function MadeRoute({
 
     return (
         <article
-            className="relative rounded-2xl border border-neutral-200/70 bg-white
-                 shadow-sm hover:shadow-md transition-shadow p-4 cursor-pointer"
+            className="relative rounded-3xl border border-neutral-200/70 bg-white
+                 shadow-sm hover:shadow-md transition-shadow p-2 cursor-pointer"
             aria-label="ルート概要カード"
             onClick={handleCardClick}
         >
@@ -210,7 +210,7 @@ export default function MadeRoute({
             <div className="flex items-start gap-3 relative">
                 {/* 左：地図サムネ（見た目だけ縮小） */}
                 <div
-                    className="shrink-0 rounded-xl overflow-hidden ring-1 ring-black/5 bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]"
+                    className="shrink-0 rounded-2xl overflow-hidden ring-1 ring-black/5 bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]"
                     style={{ width: THUMB, height: THUMB }}
                 >
                     <div

--- a/frontend/src/components/MadeRouteCard_Big.tsx
+++ b/frontend/src/components/MadeRouteCard_Big.tsx
@@ -45,13 +45,13 @@ export default function MadeRouteCard_Big({
 
     return (
         <article
-            className="relative rounded-2xl border border-neutral-200/70 bg-white shadow-sm transition-shadow p-4"
+            className="relative rounded-3xl border border-neutral-200/70 bg-white shadow-sm transition-shadow p-2"
             style={{ height: "361px" }}
             aria-label="RouteCard"
         >
             <div className="h-full flex flex-col">
                 {/* 上:地図 */}
-                <div className="flex-grow rounded-xl overflow-hidden ring-1 ring-black/5 bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]">
+                <div className="flex-grow rounded-2xl overflow-hidden ring-1 ring-black/5 bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]">
                     <RouteMap
                         positions={routePositions}
                         secondaryPositions={drawingPositions}


### PR DESCRIPTION
## 関連issue
<!-- 
関連するissue番号を記載してください。
例: Resolves #1    
-->

Resolves #73


## 変更概要
MadeRouteCard_Bigコンポーネント，MadeRouteコンポーネントの白枠と地図のpaddingを同心円状に修正．

## 動作確認方法やスクリーンショット
<img width="632" height="243" alt="image" src="https://github.com/user-attachments/assets/da20dbaf-c7d0-44fc-946b-c7062391cb8e" />
<img width="552" height="576" alt="image" src="https://github.com/user-attachments/assets/692b8006-1542-42f1-95c8-50fb055f2e40" />
