### PR TITLE
fix:おすすめ画像選択時に"描きなおす"を押せなくした

### DIFF
--- a/frontend/src/app/draw/page.tsx
+++ b/frontend/src/app/draw/page.tsx
@@ -240,10 +240,8 @@ export default function Draw() {
 
   const isCanvasDisabled = selectedShape !== null;
   
-  // ★★★ 変更点 ★★★
   // 「おすすめ選択中」または「手描きデータが空」の場合に「描き直す」を無効化
   const isClearButtonDisabled = selectedShape !== null || userDrawnPoints.length === 0;
-  // ★★★ 変更ここまで ★★★
   
   const isNextButtonDisabled = activePoints.length < 2;
 


### PR DESCRIPTION
## 変更概要
おすすめ画像選択時はかきなおすぼたんを無効化
## 動作確認方法やスクリーンショット
<img width="314" height="695" alt="image" src="https://github.com/user-attachments/assets/a23b94e8-ebc5-4588-bcf6-3774a1c45aa0" />
