### PR TITLE
コスト計算アルゴリズムを修正

### DIFF
--- a/backend/calculator/gps_art_generator.py
+++ b/backend/calculator/gps_art_generator.py
@@ -32,6 +32,7 @@ class GPSArtGenerator:
         self.path_length_adjustment = 0.7 # 目標距離の調整係数
         self.rotation_search_steps = 360 # 経路角度探索のステップ数
         self.rotation_search_points = 200 # 角度決定のためにリサンプリングする点の数
+        self.sampling_interval_m = 10.0 # C3コスト計算のサンプリング間隔（メートル）
         self._road_network = None
         self._road_network_latlon = None
         self._anchor_point = None
@@ -278,29 +279,35 @@ class GPSArtGenerator:
         return np.linalg.norm(node_coords - prev_coords)
 
     def _cost_c3(self, prev_coords: np.ndarray, node_coords: np.ndarray,
-                segment_start: np.ndarray, segment_end: np.ndarray, 
-                num_samples: int = 10) -> float:
+                segment_start: np.ndarray, segment_end: np.ndarray) -> float:
         """コスト関数 C3: 形状忠実性（理想形状との近さ）"""
+        segment_vec = segment_end - segment_start
+        segment_len = np.linalg.norm(segment_vec)
+        
+        if segment_len == 0:
+            return np.linalg.norm(prev_coords - segment_start)
+
+        num_samples = max(2, int(segment_len / self.sampling_interval_m) + 1)
+        
+        samples = segment_start + np.linspace(0, 1, num_samples)[:, np.newaxis] * segment_vec
+
         edge_vec = node_coords - prev_coords
         edge_len_sq = np.dot(edge_vec, edge_vec)
-        
+
         if edge_len_sq == 0:
-            return np.linalg.norm(prev_coords - segment_start) * num_samples
+            distances = np.linalg.norm(samples - prev_coords, axis=1)
+            return np.mean(distances)
+        vec_to_samples = samples - prev_coords
+        t = np.dot(vec_to_samples, edge_vec) / edge_len_sq
         
-        total_dist = 0
-        for k in range(num_samples):
-            sample_point = segment_start + (segment_end - segment_start) * (k / (num_samples - 1))
-            t = np.dot(sample_point - prev_coords, edge_vec) / edge_len_sq
-            
-            if t < 0:
-                dist = np.linalg.norm(sample_point - prev_coords)
-            elif t > 1:
-                dist = np.linalg.norm(sample_point - node_coords)
-            else:
-                projection = prev_coords + t * edge_vec
-                dist = np.linalg.norm(sample_point - projection)
-            total_dist += dist
-        return total_dist
+        # 0 <= t <= 1 の範囲内にあるサンプル点のみを対象
+        valid_indices = (t >= 0) & (t <= 1)
+        
+        if not np.any(valid_indices):
+            return 0.0 # 有効なサンプルがない場合はコスト0
+        projections = prev_coords + t[valid_indices, np.newaxis] * edge_vec
+        distances = np.linalg.norm(samples[valid_indices] - projections, axis=1)
+        return np.mean(distances)
 
     def _create_weight_function(self, segment_start: np.ndarray, segment_end: np.ndarray):
         """3つのコスト関数を統合した重み関数を作成します。"""


### PR DESCRIPTION
## 関連issue
<!-- 
関連するissue番号を記載してください。
例: Resolves #1    
-->

Resolves #199

## 変更概要

論文の手法にダメな点があったので経路計算アルゴリズムを改良しました。
- 手書き形状に長い直線が含まれている場合、C3(形状忠実性)の重みの計算方法に、長い道が選択されやすいバイアスがありました。

## 動作確認方法やスクリーンショット

Before 
<img width="248"  alt=" 2025-11-02 21 17 17" src="https://github.com/user-attachments/assets/2d1373c4-01bf-46f2-a895-5dd3d6850361" />

After
<img width="248" alt=" 2025-11-02 21 14 44" src="https://github.com/user-attachments/assets/839730b4-298c-4d1b-a196-b9cc36c1f0a6" />


