### PR TITLE
地図を大きくした

### DIFF
--- a/frontend/src/components/MadeRouteCard_Big.tsx
+++ b/frontend/src/components/MadeRouteCard_Big.tsx
@@ -37,7 +37,7 @@ export default function MadeRouteCard_Big({
   const drawingPositions: LatLngExpression[] = drawing_points.map((p) => [p.lat, p.lng]);
 
   const fmtKm = (v: number) => (Number.isFinite(v) ? v.toFixed(1) : "—");
-  const MAP_HEIGHT = 300;
+  const MAP_HEIGHT = 400;
 
   const mapInteractive = !isDrawingMode;
   const showZoom = !isDrawingMode;
@@ -45,7 +45,6 @@ export default function MadeRouteCard_Big({
   return (
     <article
       className="relative rounded-3xl border border-neutral-200/70 bg-white shadow-sm transition-shadow p-2 pb-4 font-sans"
-      style={{ height: "361px" }}
       aria-label="RouteCard"
     >
       <div className="h-full flex flex-col">


### PR DESCRIPTION
## 関連issue
<!-- 
関連するissue番号を記載してください。
例: Resolves #1    
-->

## 変更概要

地図を100px縦に大きくしました
編集とかやりやすそう

## 動作確認方法やスクリーンショット
<img width="492" height="932" alt=" 2025-11-04 15 54 10" src="https://github.com/user-attachments/assets/5526b940-1b3d-43c5-9f7b-16af117e88c7" />




