### PR TITLE
特定のスクロール位置で経路微調整の線がギザギザする問題を解決

### DIFF
--- a/frontend/src/app/route/page.tsx
+++ b/frontend/src/app/route/page.tsx
@@ -246,7 +246,7 @@ export default function CourseDetailPage() {
 
   if (!memoizedRouteData) {
     return (
-      <div className="bg-gray-50 min-h-screen">
+      <div className="bg-gray-50">
         <main className="max-w-md mx-auto p-4">
           <div className="text-center py-8">
             <Text text="データを読み込んでいます..." />
@@ -257,7 +257,7 @@ export default function CourseDetailPage() {
   }
 
   return (
-    <div className="bg-gray-50 min-h-screen">
+    <div className="bg-gray-50">
       <main className="max-w-md mx-auto px-4 pb-28 pt-4">
         {/* 見出し */}
         <div className="text-left mb-2 font-sans">


### PR DESCRIPTION
## 関連issue
<!-- 
関連するissue番号を記載してください。
例: Resolves #1    
-->

Resolves #223

## 変更概要

- スクロール位置によっては線がブレる問題
- min-h-screenはiOSとの相性が悪い

## 動作確認方法やスクリーンショット
